### PR TITLE
fixed bug preventing use of grsm.block option

### DIFF
--- a/R/03-estimation.R
+++ b/R/03-estimation.R
@@ -111,6 +111,7 @@ ESTIMATION <- function(data, model, group, itemtype = NULL, guess = 0, upper = 1
         if(any(rowSums(is.na(data)) == ncol(data)))
             stop('data contains completely empty response patterns. Please remove', call.=FALSE)
         if(is.null(opts$grsm.block)) Data$grsm.block <- rep(1L, ncol(data))
+        else Data$grsm.block <- opts$grsm.block
         # if(is.null(opts$rsm.block)) Data$rsm.block <- rep(1L, ncol(data))
         Data$group <- factor(group)
         Data$groupNames <- unique(Data$group)


### PR DESCRIPTION
The "grsm.block" option of the mirt function was not passed down in the estimation object and in consequence the default "grsm.block <- rep(1, ncol(data))" was always used.