### PR TITLE
Small Correction for a simple typing error

### DIFF
--- a/R/M2.R
+++ b/R/M2.R
@@ -75,7 +75,7 @@ M2 <- function(obj, calcNull = TRUE, quadpts = NULL, theta_lim = c(-6, 6),
     #if MG loop
     if(missing(obj)) missingMsg('obj')
     if(is(obj, 'MixedClass'))
-        stop('mixedmirt objects not yet supported', call.=FALSE)
+        stop('MixedClass objects are not yet supported', call.=FALSE)
     if(QMC && is.null(quadpts)) quadpts <- 15000L
     discrete <- FALSE
     if(is(obj, 'DiscreteClass')){

--- a/R/imputeMissing.R
+++ b/R/imputeMissing.R
@@ -40,13 +40,13 @@ imputeMissing <- function(x, Theta, ...){
     if(missing(x)) missingMsg('x')
     if(missing(Theta)) missingMsg('Theta')
     if(is(x, 'MixedClass'))
-        stop('mixedmirt xs not yet supported', call.=FALSE)
+        stop('MixedClass objects is not yet supported.', call.=FALSE)
     if(is(x, 'MultipleGroupClass')){
         pars <- x@ParObjects$pars
         group <- x@Data$group
         data <- x@Data$data
         if(sum(is.na(data))/length(data) > .1)
-            warning('Imputing too much data can lead to very conservative results. Use with caution',
+            warning('Imputing too much data can lead to very conservative results. Use with caution.',
                     call.=FALSE)
         uniq_rows <- apply(data, 2L, function(x) list(sort(na.omit(unique(x)))))
         for(g in 1L:length(pars)){
@@ -77,7 +77,7 @@ imputeMissing <- function(x, Theta, ...){
     J <- length(K)
     data <- x@Data$data
     if(sum(is.na(data))/length(data) > .1)
-        warning('Imputing too much data can lead to very conservative results. Use with caution',
+        warning('Imputing too much data can lead to very conservative results. Use with caution.',
                 call.=FALSE)
     N <- nrow(data)
     Nind <- 1L:N

--- a/R/imputeMissing.R
+++ b/R/imputeMissing.R
@@ -40,7 +40,7 @@ imputeMissing <- function(x, Theta, ...){
     if(missing(x)) missingMsg('x')
     if(missing(Theta)) missingMsg('Theta')
     if(is(x, 'MixedClass'))
-        stop('MixedClass objects is not yet supported.', call.=FALSE)
+        stop('MixedClass objects are not yet supported.', call.=FALSE)
     if(is(x, 'MultipleGroupClass')){
         pars <- x@ParObjects$pars
         group <- x@Data$group

--- a/R/itemfit.R
+++ b/R/itemfit.R
@@ -144,7 +144,7 @@ itemfit <- function(x, Zh = TRUE, X2 = FALSE, S_X2 = TRUE, group.size = 150, min
 
     if(missing(x)) missingMsg('x')
     if(is(x, 'MixedClass'))
-        stop('mixedmirt objects not supported', call.=FALSE)
+        stop('MixedClass objects not supported', call.=FALSE)
     discrete <- FALSE
     if(is(x, 'DiscreteClass')){
         class(x) <- 'MultipleGroupClass'

--- a/R/itemfit.R
+++ b/R/itemfit.R
@@ -144,7 +144,7 @@ itemfit <- function(x, Zh = TRUE, X2 = FALSE, S_X2 = TRUE, group.size = 150, min
 
     if(missing(x)) missingMsg('x')
     if(is(x, 'MixedClass'))
-        stop('MixedClass objects not supported', call.=FALSE)
+        stop('MixedClass objects are not supported', call.=FALSE)
     discrete <- FALSE
     if(is(x, 'DiscreteClass')){
         class(x) <- 'MultipleGroupClass'


### PR DESCRIPTION
Small Correction for a simple typing error:

* 'xs' to 'is'
* 'mixedmirt' to 'MixedClass' (because, someone tried to supply MixedClass objects, not 'mixedmirt' function)