### PR TITLE
patch for verbose message seems ugly for Rstudio users

### DIFF
--- a/R/EMstep.group.R
+++ b/R/EMstep.group.R
@@ -212,7 +212,7 @@ EM.group <- function(pars, constrain, Ls, Data, PrepList, list, Theta, DERIV, so
                               control=control)
             EMhistory[cycles+1L,] <- longpars
             if(verbose)
-                cat(sprintf('\rIteration: %d, Log-Lik: %.3f, Max-Change: %.5f',
+                cat(sprintf('\nIteration: %d, Log-Lik: %.3f, Max-Change: %.5f',
                             cycles, LL, max(abs(preMstep.longpars - longpars))))
             if(all(abs(preMstep.longpars - longpars) < TOL)){
                 pars <- reloadPars(longpars=longpars, pars=pars,

--- a/R/MHRM.group.R
+++ b/R/MHRM.group.R
@@ -363,13 +363,13 @@ MHRM.group <- function(pars, constrain, Ls, Data, PrepList, list, random = list(
             AR <- paste0(sapply(AR, function(x) sprintf('%.2f', x)), collapse='; ')
             CTV <- paste0(sapply(CTV, function(x) sprintf('%.2f', x)), collapse='; ')
             if(cycles <= BURNIN)
-                printmsg <- sprintf("\rStage 1 = %i, LL = %.1f, AR(%s) = [%s]",
+                printmsg <- sprintf("\nStage 1 = %i, LL = %.1f, AR(%s) = [%s]",
                                     cycles, LL, CTV, AR)
             if(cycles > BURNIN && cycles <= BURNIN + SEMCYCLES)
-                printmsg <- sprintf("\rStage 2 = %i, LL = %.1f, AR(%s) = [%s]",
+                printmsg <- sprintf("\nStage 2 = %i, LL = %.1f, AR(%s) = [%s]",
                                     cycles-BURNIN, LL, CTV, AR)
             if(cycles > BURNIN + SEMCYCLES)
-                printmsg <- sprintf("\rStage 3 = %i, LL = %.1f, AR(%s) = [%s]",
+                printmsg <- sprintf("\nStage 3 = %i, LL = %.1f, AR(%s) = [%s]",
                                     cycles-BURNIN-SEMCYCLES, LL, CTV, AR)
         }
         if(stagecycle < 3L){


### PR DESCRIPTION
patch for verbose message seems ugly for Rstudio users when logout and
login during estimating models; espacially Rstudio Server users who using Linux machines.

Linux may not print '\r' (Line Feed) well than Mac. See http://stackoverflow.com/a/15433225 documentation; Carriage Return were used as a new line character in Mac OS before X. After Mac OS X, '\n' (Carriage Return) Used as a new line character in Unix/Mac OS X.

* Make Changes '\r' to '\n' in two files.