### PR TITLE
estfun.AllModelClass: small bugfix for multipleGroup models regarding factor levels 

### DIFF
--- a/R/estfun.R
+++ b/R/estfun.R
@@ -85,6 +85,7 @@ estfun.AllModelClass <- function(object) {
   L <- Ls$L
   redun_constr <- Ls$redun_constr
   epars <- mod2values(object)
+  epars$group <- factor(epars$group, levels = groupNames)
   eparsgroup <- split(epars, epars$group)
   sel <- lapply(eparsgroup, function(x) x$parnum[x$est])
   ### constrains; cb = between groups, cw = within groups


### PR DESCRIPTION
This allows for the levels of the group variable of multipleGroup models to be uncanonically ordered.