### PR TITLE
simply add the "future.apply" API into the my*Apply()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -2354,7 +2354,11 @@ missingMsg <- function(string)
 
 myApply <- function(X, MARGIN, FUN, ...){
     if(.mirtClusterEnv$ncores > 1L){
-        return(t(parallel::parApply(cl=.mirtClusterEnv$MIRTCLUSTER, X=X, MARGIN=MARGIN, FUN=FUN, ...)))
+        if('future.apply' %in% rownames(installed.packages())){
+            return(t(future.apply::future_apply(X=X, MARGIN=MARGIN, FUN=FUN, ...)))
+        } else {
+            return(t(parallel::parApply(cl=.mirtClusterEnv$MIRTCLUSTER, X=X, MARGIN=MARGIN, FUN=FUN, ...)))
+        }
     } else {
         return(t(apply(X=X, MARGIN=MARGIN, FUN=FUN, ...)))
     }
@@ -2362,7 +2366,11 @@ myApply <- function(X, MARGIN, FUN, ...){
 
 myLapply <- function(X, FUN, ...){
     if(.mirtClusterEnv$ncores > 1L){
-        return(parallel::parLapply(cl=.mirtClusterEnv$MIRTCLUSTER, X=X, fun=FUN, ...))
+        if('future.apply' %in% rownames(installed.packages())){
+            return(t(future.apply::future_lapply(X=X, FUN=FUN, ...)))
+        } else {
+            return(parallel::parLapply(cl=.mirtClusterEnv$MIRTCLUSTER, X=X, fun=FUN, ...))
+        }
     } else {
         return(lapply(X=X, FUN=FUN, ...))
     }
@@ -2370,7 +2378,11 @@ myLapply <- function(X, FUN, ...){
 
 mySapply <- function(X, FUN, ...){
     if(.mirtClusterEnv$ncores > 1L){
-        return(t(parallel::parSapply(cl=.mirtClusterEnv$MIRTCLUSTER, X=X, FUN=FUN, ...)))
+        if('future.apply' %in% rownames(installed.packages())){
+            return(t(future.apply::future_sapply(X=X, FUN=FUN, ...)))
+        } else {
+            return(t(parallel::parSapply(cl=.mirtClusterEnv$MIRTCLUSTER, X=X, FUN=FUN, ...)))
+        }
     } else {
         return(t(sapply(X=X, FUN=FUN, ...)))
     }


### PR DESCRIPTION
Contents: Add the "future.apply" API into the my*Apply() functions

Reason
1. Sometimes (unlucky) item fit calculation too slow to wait, that's so painful.
2. The "future.apply" API could do parallel computing among the computing cluster very flexible, with execute ```future::plan('cluster')``` command.
3. Rising the utility of the "future.apply" library around the psychometrics libraries (e.g. brms) and High-performance Computing libraries (e.g. doFuture). 

Affection
1. If someone has the "future.apply" API already; The my*Apply family function will be run in parallel with user customised parallel setting.
2. If not, This modification will not affect the previous behaviour; parallel::par*Apply will be work.

Please consider merging this modification.

Best,
Seongho