### PR TITLE
Centering in estfun function

### DIFF
--- a/R/estfun.R
+++ b/R/estfun.R
@@ -23,7 +23,11 @@
 #'   square root if the scores are being used to compute the outer product of
 #'   gradients (OPG) estimate of the variance-covariance matrix (see examples
 #'   below).
-#' @author Lennart Schneider \email{lennart.sch@@web.de}
+#' @param centering a boolean variable that allows the centering of the case-wise 
+#' scores (i.e., setting their expected value to 0). If the case-wise scores were 
+#' obtained from maximum likelihood estimates, this setting does not affect the result. 
+#' 
+#' @author Lennart Schneider \email{lennart.sch@@web.de}; centering argument contributed by Rudolf Debelak (rudolf.debelak@psychologie.uzh.ch)
 #' @keywords scores
 #' @seealso \code{\link{mirt}}, \code{\link{multipleGroup}},
 #'   \code{\link{bfactor}}
@@ -76,7 +80,7 @@
 #'
 #'}
 
-estfun.AllModelClass <- function(x, weights = extract.mirt(x, "survey.weights", centering=TRUE))
+estfun.AllModelClass <- function(x, weights = extract.mirt(x, "survey.weights"), centering=TRUE)
 {
   ## check class
   stopifnot(class(x) %in% c("SingleGroupClass", "MultipleGroupClass"))
@@ -207,7 +211,7 @@ estfun.AllModelClass <- function(x, weights = extract.mirt(x, "survey.weights", 
   ## apply centering
   if(centering){
     corrector <- apply(scores, 2, mean)
-    t(apply(scores, 1, function(x) x - corrector))
+    t(apply(scores, 1, function(x) {x - corrector}))
   }          
   ## apply proper naming
   colnames(scores) <-

--- a/R/estfun.R
+++ b/R/estfun.R
@@ -24,10 +24,10 @@
 #'   gradients (OPG) estimate of the variance-covariance matrix (see examples
 #'   below).
 #' @param centering a boolean variable that allows the centering of the case-wise 
-#' scores (i.e., setting their expected value to 0). If the case-wise scores were 
+#' scores (i.e., setting their expected values to 0). If the case-wise scores were 
 #' obtained from maximum likelihood estimates, this setting does not affect the result. 
 #' 
-#' @author Lennart Schneider \email{lennart.sch@@web.de}; centering argument contributed by Rudolf Debelak (rudolf.debelak@psychologie.uzh.ch)
+#' @author Lennart Schneider \email{lennart.sch@@web.de}; centering argument contributed by Rudolf Debelak (\email{rudolf.debelak@psychologie.uzh.ch})
 #' @keywords scores
 #' @seealso \code{\link{mirt}}, \code{\link{multipleGroup}},
 #'   \code{\link{bfactor}}

--- a/R/estfun.R
+++ b/R/estfun.R
@@ -204,6 +204,11 @@ estfun.AllModelClass <- function(x, weights = extract.mirt(x, "survey.weights"))
     weights <- rep.int(1L, Data$N)
   }
   scores <- scores * weights
+  ## apply centering
+  if(centering){
+    corrector <- apply(scores, 2, mean)
+    t(apply(scores, 1, function(x) x - corrector))
+  }          
   ## apply proper naming
   colnames(scores) <-
   if(x@Options$SE) {

--- a/R/estfun.R
+++ b/R/estfun.R
@@ -76,7 +76,7 @@
 #'
 #'}
 
-estfun.AllModelClass <- function(x, weights = extract.mirt(x, "survey.weights"))
+estfun.AllModelClass <- function(x, weights = extract.mirt(x, "survey.weights", centering=TRUE))
 {
   ## check class
   stopifnot(class(x) %in% c("SingleGroupClass", "MultipleGroupClass"))


### PR DESCRIPTION
The estfun function was updated to allow centering of the case-wise score contributions (i.e., setting their expected values over all persons to 0). This centering does not affect the results of this function in a maximum likelihood framework, but allows the application of score-based invariance tests in Bayesian framework.