### PR TITLE
fixed NA values in upper triangular part of cov matrix

### DIFF
--- a/R/SingleGroup-methods.R
+++ b/R/SingleGroup-methods.R
@@ -387,6 +387,7 @@ setMethod(
                 if(object@ParObjects$pars[[J+1L]]@dentype == "Davidian"){
                     covs <- matrix(NA, nfact, nfact)
                     covs[lower.tri(covs, TRUE)] <- allPars$GroupPars[2L]
+                    covs[upper.tri(covs, F)] <- covs[lower.tri(covs, F)]
                     colnames(covs) <- rownames(covs) <- names(means) <- object@Model$factorNames[seq_len(nfact)]
                     allPars <- list(items=items, means=means, cov=covs,
                                     Davidian_phis=allPars$GroupPars[-c(1:2)])
@@ -395,6 +396,7 @@ setMethod(
                     if(object@ParObjects$pars[[J+1L]]@dentype == "mixture")
                         covs[lower.tri(covs, TRUE)] <- allPars$GroupPars[-c(seq_len(nfact), length(allPars$GroupPars))]
                     else covs[lower.tri(covs, TRUE)] <- allPars$GroupPars[-seq_len(nfact)]
+                    covs[upper.tri(covs, F)] <- covs[lower.tri(covs, F)]
                     colnames(covs) <- rownames(covs) <- names(means) <- object@Model$factorNames[seq_len(nfact)]
                     allPars <- list(items=items, means=means, cov=covs)
                 }

--- a/R/SingleGroup-methods.R
+++ b/R/SingleGroup-methods.R
@@ -387,7 +387,7 @@ setMethod(
                 if(object@ParObjects$pars[[J+1L]]@dentype == "Davidian"){
                     covs <- matrix(NA, nfact, nfact)
                     covs[lower.tri(covs, TRUE)] <- allPars$GroupPars[2L]
-                    covs[upper.tri(covs, F)] <- covs[lower.tri(covs, F)]
+                    covs[upper.tri(covs, FALSE)] <- covs[lower.tri(covs, FALSE)]
                     colnames(covs) <- rownames(covs) <- names(means) <- object@Model$factorNames[seq_len(nfact)]
                     allPars <- list(items=items, means=means, cov=covs,
                                     Davidian_phis=allPars$GroupPars[-c(1:2)])
@@ -396,7 +396,7 @@ setMethod(
                     if(object@ParObjects$pars[[J+1L]]@dentype == "mixture")
                         covs[lower.tri(covs, TRUE)] <- allPars$GroupPars[-c(seq_len(nfact), length(allPars$GroupPars))]
                     else covs[lower.tri(covs, TRUE)] <- allPars$GroupPars[-seq_len(nfact)]
-                    covs[upper.tri(covs, F)] <- covs[lower.tri(covs, F)]
+                    covs[upper.tri(covs, FALSE)] <- covs[lower.tri(covs, FALSE)]
                     colnames(covs) <- rownames(covs) <- names(means) <- object@Model$factorNames[seq_len(nfact)]
                     allPars <- list(items=items, means=means, cov=covs)
                 }


### PR DESCRIPTION
For a multidimensional model fit `coef(fit, simplify = T)` returned a matrix with NA value in the upper triangular part. This also lead to an error when simulating from a multidimensional model using `simdata(model=fit)`. 
This pull request fixes these problems.