### PR TITLE
flush.console() after cat(sprintf(...))

### DIFF
--- a/R/DIF.R
+++ b/R/DIF.R
@@ -434,7 +434,7 @@ DIF <- function(MGmodel, which.par, scheme = 'add',
                 lastkeep <- keep | lastkeep
             } else lastkeep <- keep
             if(verbose)
-                cat(sprintf('\rChecking for DIF in %d more items', if(drop) sum(keep) else sum(!keep)))
+                printf('\rChecking for DIF in %d more items', if(drop) sum(keep) else sum(!keep))
             if(ifelse(drop, sum(keep), sum(!keep)) == 0) break
             constrain <- updatedModel@Model$constrain
             for(j in seq_len(length(keep))){

--- a/R/EMstep.group.R
+++ b/R/EMstep.group.R
@@ -315,8 +315,8 @@ EM.group <- function(pars, constrain, Ls, Data, PrepList, list, Theta, DERIV, so
                 }
             }
             if(verbose)
-                cat(sprintf('\rIteration: %d, Log-Lik: %.3f, Max-Change: %.5f',
-                            cycles, LL + LP, max(abs(preMstep.longpars - longpars))))
+                printf('\rIteration: %d, Log-Lik: %.3f, Max-Change: %.5f',
+                            cycles, LL + LP, max(abs(preMstep.longpars - longpars)))
 
             if(hasConverged(preMstep.longpars, longpars, TOL)){
                 pars <- reloadPars(longpars=longpars, pars=pars,

--- a/R/utils.R
+++ b/R/utils.R
@@ -2836,3 +2836,8 @@ mySapply <- function(X, FUN, progress = FALSE, ...){
         return(t(sapply(X=X, FUN=FUN, ...)))
     }
 }
+
+printf <- function(...) {
+  cat(sprintf(...))
+  flush.console() # print immediately
+}


### PR DESCRIPTION
In certain scenarios, such as when using an `R` kernel in `JupyterLab`, the console does not flush automatically after calling `cat()`. This leads to delayed output, where real-time feedback is not displayed during execution. For instance, when running the `mirt()` function, the `Log-Lik` and `Max-Change` values are only visible after the function completes, preventing iterative monitoring.

To address this, I created a new utility function, `printf()`, within utils.R. This function combines `sprintf()` and `flush.console()` to format output and immediately flush it to the console. `printf()`, ensures that the output is printed immediately.