### PR TITLE
perf: parallelize item trace computation

### DIFF
--- a/R/EMstep.utils.R
+++ b/R/EMstep.utils.R
@@ -37,7 +37,7 @@ Estep.mirt <- function(pars, tabdata, freq, Theta, prior, itemloc, CUSTOM.IND, w
 {
     if(is.null(itemtrace))
         itemtrace <- computeItemtrace(pars=pars, Theta=Theta, itemloc=itemloc,
-                                      CUSTOM.IND=CUSTOM.IND)
+                                      CUSTOM.IND=CUSTOM.IND, omp_threads=omp_threads)
     retlist <- if(full) .Call("Estep2", itemtrace, prior, tabdata,
                               wmiss, Etable, omp_threads)
         else .Call("Estep", itemtrace, prior, tabdata, freq,
@@ -52,7 +52,7 @@ Estep.bfactor <- function(pars, tabdata, freq, Theta, prior, Priorbetween, speci
 {
     if(is.null(itemtrace))
         itemtrace <- computeItemtrace(pars=pars, Theta=Theta, itemloc=itemloc,
-                                      CUSTOM.IND=CUSTOM.IND)
+                                      CUSTOM.IND=CUSTOM.IND, omp_threads=omp_threads)
     retlist <- .Call("Estepbfactor", itemtrace, prior, Priorbetween, tabdata,
                      freq, sitems, wmiss, Etable, omp_threads)
     return(retlist)
@@ -67,7 +67,8 @@ Estep.mixture <- function(pars, tabdata, freq, Theta, prior, itemloc, CUSTOM.IND
         itemtrace <- vector('list', ngroups)
         for(g in seq_len(ngroups))
             itemtrace[[g]] <- computeItemtrace(pars=pars[[g]], Theta=Theta,
-                                               itemloc=itemloc, CUSTOM.IND=CUSTOM.IND)
+                                               itemloc=itemloc, CUSTOM.IND=CUSTOM.IND,
+                                               omp_threads=omp_threads)
     }
     tmp <- .Call("Estep", do.call(rbind, itemtrace),
                  do.call(c, prior), tabdata, freq, wmiss, Etable, omp_threads)

--- a/R/mirtCluster.R
+++ b/R/mirtCluster.R
@@ -12,7 +12,7 @@
 #' @param spec input that is passed to \code{parallel::makeCluster()}. If no input is given the
 #'   maximum number of available local cores minus 1 will be used.
 #'   Setting this to NULL will skip a new definition (allows \code{omp_threads} to be used independently)
-#' @param omp_threads number of OpenMP threads to use (currently applies to E-step computations only).
+#' @param omp_threads number of OpenMP threads to use for OpenMP-backed E-step and item trace computations.
 #'   Not used when argument input is missing
 #' @param use_mirai logical; use the \code{mirai} cluster definition instead of \code{parallel}?
 #' @param ... additional arguments to pass to \code{parallel::makeCluster}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1888,9 +1888,9 @@ reloadPars <- function(longpars, pars, ngroups, J){
 }
 
 computeItemtrace <- function(pars, Theta, itemloc, offterm = matrix(0L, 1L, length(itemloc)-1L),
-                             CUSTOM.IND, pis = NULL){
+                             CUSTOM.IND, pis = NULL, omp_threads = .mirtClusterEnv$omp_threads){
     if(is.null(pis)){
-        itemtrace <- .Call('computeItemTrace', pars, Theta, itemloc, offterm)
+        itemtrace <- .Call('computeItemTrace', pars, Theta, itemloc, offterm, as.integer(omp_threads))
         if(length(CUSTOM.IND)){
             for(i in CUSTOM.IND){
                 Thetas <- Theta
@@ -1902,7 +1902,8 @@ computeItemtrace <- function(pars, Theta, itemloc, offterm = matrix(0L, 1L, leng
     } else {
         tmp_itemtrace <- vector('list', length(pis))
         for(g in seq_len(length(pis))){
-            tmp_itemtrace[[g]] <- .Call('computeItemTrace', pars[[g]]@ParObjects$pars, Theta, itemloc, offterm)
+            tmp_itemtrace[[g]] <- .Call('computeItemTrace', pars[[g]]@ParObjects$pars, Theta, itemloc,
+                                        offterm, as.integer(omp_threads))
             if(length(CUSTOM.IND)){
                 for(i in CUSTOM.IND){
                     Thetas <- Theta

--- a/dev/bench_compare.R
+++ b/dev/bench_compare.R
@@ -1,0 +1,175 @@
+#!/usr/bin/env Rscript
+# Benchmark script compatible with both main and refactor/openmp branches
+
+suppressPackageStartupMessages(library(microbenchmark))
+
+args <- commandArgs(trailingOnly = TRUE)
+arg_value <- function(name, default = NULL) {
+  key <- paste0("--", name, "=")
+  hit <- args[startsWith(args, key)]
+  if (length(hit) == 0L) return(default)
+  sub(key, "", hit[[1L]], fixed = TRUE)
+}
+
+arg_int <- function(name, default) {
+  as.integer(arg_value(name, as.character(default)))
+}
+
+mode <- arg_value("mode", "baseline")
+repo <- normalizePath(arg_value("repo", "."), mustWork = TRUE)
+out <- arg_value("out", "")
+lib_loc <- arg_value("lib", "")
+dataset <- arg_value("dataset", "sim")
+
+N_prepare <- arg_int("n_prepare", 50000L)
+N_fit <- arg_int("n_fit", 12000L)
+J <- arg_int("j", 40L)
+theta_n <- arg_int("theta_n", 20000L)
+omp_threads <- arg_int("omp_threads", 1L)
+times_prepare <- arg_int("times_prepare", 5L)
+times_fit <- arg_int("times_fit", 3L)
+times_eapsum <- arg_int("times_eapsum", 5L)
+times_itemtrace <- arg_int("times_itemtrace", 5L)
+
+if (!mode %in% c("baseline", "head")) {
+  stop("--mode must be one of: baseline, head")
+}
+
+if (!dataset %in% c("sim", "sat12")) {
+  stop("--dataset must be one of: sim, sat12")
+}
+
+if (mode == "baseline") {
+  if (nzchar(lib_loc)) {
+    suppressPackageStartupMessages(library("mirt", lib.loc = lib_loc, character.only = TRUE))
+  } else {
+    suppressPackageStartupMessages(library(mirt))
+  }
+} else {
+  if (nzchar(lib_loc)) {
+    suppressPackageStartupMessages(library("mirt", lib.loc = lib_loc, character.only = TRUE))
+  } else {
+    if (!requireNamespace("pkgload", quietly = TRUE)) {
+      stop("pkgload is required for --mode=head without --lib")
+    }
+    pkgload::load_all(repo, compile = FALSE, quiet = TRUE)
+  }
+}
+
+# Check if omp_threads parameter is supported
+has_omp_support <- FALSE
+tryCatch({
+  # Try to call with omp_threads parameter
+  data("SAT12", package = "mirt", envir = environment())
+  key <- c(1, 4, 5, 2, 3, 1, 2, 1, 3, 1, 2, 4, 2, 1, 5, 3,
+           4, 4, 1, 4, 3, 3, 4, 1, 3, 5, 1, 3, 1, 5, 4, 5)
+  SAT12[SAT12 == 8] <- NA
+  dat_test <- key2binary(SAT12, key)
+  mod_test <- mirt(dat_test, 1, verbose = FALSE, technical = list(NCYCLES = 5L))
+  Theta_test <- matrix(seq(-6, 6, length.out = 100))
+  # This will fail on main branch
+  invisible(mirt:::computeItemtrace(mod_test@ParObjects$pars, Theta_test, 
+                                    mod_test@Model$itemloc, 
+                                    CUSTOM.IND = mod_test@Internals$CUSTOM.IND,
+                                    omp_threads = 1L))
+  has_omp_support <- TRUE
+}, error = function(e) {
+  has_omp_support <<- FALSE
+})
+
+set.seed(20260227)
+if (dataset == "sim") {
+  a <- matrix(abs(rnorm(J, mean = 1.1, sd = 0.2)), ncol = 1L)
+  d <- rnorm(J, mean = -0.1, sd = 0.9)
+  dat_prepare <- simdata(a, d, N = N_prepare, itemtype = "2PL")
+  dat_fit <- simdata(a, d, N = N_fit, itemtype = "2PL")
+  itemtype <- "2PL"
+} else {
+  data("SAT12", package = "mirt", envir = environment())
+  key <- c(1, 4, 5, 2, 3, 1, 2, 1, 3, 1, 2, 4, 2, 1, 5, 3,
+           4, 4, 1, 4, 3, 3, 4, 1, 3, 5, 1, 3, 1, 5, 4, 5)
+  SAT12[SAT12 == 8] <- NA
+  dat_prepare <- dat_fit <- key2binary(SAT12, key)
+  itemtype <- NULL
+  N_prepare <- N_fit <- nrow(dat_fit)
+  J <- ncol(dat_fit)
+}
+
+bench_prepare <- microbenchmark(
+  prepare_large = mirt(dat_prepare, 1, itemtype = itemtype, large = "return", verbose = FALSE),
+  times = times_prepare,
+  unit = "ms"
+)
+
+bench_fit <- microbenchmark(
+  fit_large = mirt(dat_fit, 1, itemtype = itemtype, verbose = FALSE,
+                   technical = list(NCYCLES = 40L)),
+  times = times_fit,
+  unit = "ms"
+)
+
+mod_for_scores <- mirt(dat_fit, 1, itemtype = itemtype, verbose = FALSE,
+                       technical = list(NCYCLES = 40L))
+Theta_itemtrace <- matrix(seq(-6, 6, length.out = theta_n), ncol = 1L)
+
+# Use omp_threads only if supported
+if (has_omp_support) {
+  bench_itemtrace <- microbenchmark(
+    itemtrace_large = mirt:::computeItemtrace(
+      mod_for_scores@ParObjects$pars,
+      Theta_itemtrace,
+      mod_for_scores@Model$itemloc,
+      CUSTOM.IND = mod_for_scores@Internals$CUSTOM.IND,
+      omp_threads = omp_threads
+    ),
+    times = times_itemtrace,
+    unit = "ms"
+  )
+} else {
+  bench_itemtrace <- microbenchmark(
+    itemtrace_large = mirt:::computeItemtrace(
+      mod_for_scores@ParObjects$pars,
+      Theta_itemtrace,
+      mod_for_scores@Model$itemloc,
+      CUSTOM.IND = mod_for_scores@Internals$CUSTOM.IND
+    ),
+    times = times_itemtrace,
+    unit = "ms"
+  )
+}
+
+bench_eapsum <- microbenchmark(
+  eapsum_large = fscores(mod_for_scores, method = "EAPsum", full.scores = TRUE),
+  times = times_eapsum,
+  unit = "ms"
+)
+
+to_row <- function(name, bench, n_obs, n_items) {
+  data.frame(
+    mode = mode,
+    dataset = dataset,
+    has_omp = has_omp_support,
+    benchmark = name,
+    N = n_obs,
+    J = n_items,
+    theta_n = theta_n,
+    omp_threads = if(has_omp_support) omp_threads else NA,
+    times = nrow(bench),
+    median_ms = unname(median(bench$time) / 1e6),
+    mean_ms = unname(mean(bench$time) / 1e6),
+    stringsAsFactors = FALSE
+  )
+}
+
+res <- rbind(
+  to_row("prepare_large", bench_prepare, N_prepare, J),
+  to_row("fit_large", bench_fit, N_fit, J),
+  to_row("itemtrace_large", bench_itemtrace, theta_n, J),
+  to_row("eapsum_large", bench_eapsum, N_fit, J)
+)
+
+if (nzchar(out)) {
+  write.csv(res, file = out, row.names = FALSE)
+} else {
+  print(res)
+}

--- a/dev/microbenchmark_compare.R
+++ b/dev/microbenchmark_compare.R
@@ -18,16 +18,24 @@ mode <- arg_value("mode", "baseline")
 repo <- normalizePath(arg_value("repo", "."), mustWork = TRUE)
 out <- arg_value("out", "")
 lib_loc <- arg_value("lib", "")
+dataset <- arg_value("dataset", "sim")
 
 N_prepare <- arg_int("n_prepare", 50000L)
 N_fit <- arg_int("n_fit", 12000L)
 J <- arg_int("j", 40L)
+theta_n <- arg_int("theta_n", 20000L)
+omp_threads <- arg_int("omp_threads", 1L)
 times_prepare <- arg_int("times_prepare", 5L)
 times_fit <- arg_int("times_fit", 3L)
 times_eapsum <- arg_int("times_eapsum", 5L)
+times_itemtrace <- arg_int("times_itemtrace", 5L)
 
 if (!mode %in% c("baseline", "head")) {
   stop("--mode must be one of: baseline, head")
+}
+
+if (!dataset %in% c("sim", "sat12")) {
+  stop("--dataset must be one of: sim, sat12")
 }
 
 if (mode == "baseline") {
@@ -48,27 +56,51 @@ if (mode == "baseline") {
 }
 
 set.seed(20260227)
-a <- matrix(abs(rnorm(J, mean = 1.1, sd = 0.2)), ncol = 1L)
-d <- rnorm(J, mean = -0.1, sd = 0.9)
-
-dat_prepare <- simdata(a, d, N = N_prepare, itemtype = "2PL")
-dat_fit <- simdata(a, d, N = N_fit, itemtype = "2PL")
+if (dataset == "sim") {
+  a <- matrix(abs(rnorm(J, mean = 1.1, sd = 0.2)), ncol = 1L)
+  d <- rnorm(J, mean = -0.1, sd = 0.9)
+  dat_prepare <- simdata(a, d, N = N_prepare, itemtype = "2PL")
+  dat_fit <- simdata(a, d, N = N_fit, itemtype = "2PL")
+  itemtype <- "2PL"
+} else {
+  data("SAT12", package = "mirt", envir = environment())
+  key <- c(1, 4, 5, 2, 3, 1, 2, 1, 3, 1, 2, 4, 2, 1, 5, 3,
+           4, 4, 1, 4, 3, 3, 4, 1, 3, 5, 1, 3, 1, 5, 4, 5)
+  SAT12[SAT12 == 8] <- NA
+  dat_prepare <- dat_fit <- key2binary(SAT12, key)
+  itemtype <- NULL
+  N_prepare <- N_fit <- nrow(dat_fit)
+  J <- ncol(dat_fit)
+}
 
 bench_prepare <- microbenchmark(
-  prepare_large = mirt(dat_prepare, 1, itemtype = "2PL", large = "return", verbose = FALSE),
+  prepare_large = mirt(dat_prepare, 1, itemtype = itemtype, large = "return", verbose = FALSE),
   times = times_prepare,
   unit = "ms"
 )
 
 bench_fit <- microbenchmark(
-  fit_large = mirt(dat_fit, 1, itemtype = "2PL", verbose = FALSE,
+  fit_large = mirt(dat_fit, 1, itemtype = itemtype, verbose = FALSE,
                    technical = list(NCYCLES = 40L)),
   times = times_fit,
   unit = "ms"
 )
 
-mod_for_scores <- mirt(dat_fit, 1, itemtype = "2PL", verbose = FALSE,
+mod_for_scores <- mirt(dat_fit, 1, itemtype = itemtype, verbose = FALSE,
                        technical = list(NCYCLES = 40L))
+Theta_itemtrace <- matrix(seq(-6, 6, length.out = theta_n), ncol = 1L)
+
+bench_itemtrace <- microbenchmark(
+  itemtrace_large = mirt:::computeItemtrace(
+    mod_for_scores@ParObjects$pars,
+    Theta_itemtrace,
+    mod_for_scores@Model$itemloc,
+    CUSTOM.IND = mod_for_scores@Internals$CUSTOM.IND,
+    omp_threads = omp_threads
+  ),
+  times = times_itemtrace,
+  unit = "ms"
+)
 
 bench_eapsum <- microbenchmark(
   eapsum_large = fscores(mod_for_scores, method = "EAPsum", full.scores = TRUE),
@@ -79,9 +111,12 @@ bench_eapsum <- microbenchmark(
 to_row <- function(name, bench, n_obs, n_items) {
   data.frame(
     mode = mode,
+    dataset = dataset,
     benchmark = name,
     N = n_obs,
     J = n_items,
+    theta_n = theta_n,
+    omp_threads = omp_threads,
     times = nrow(bench),
     median_ms = unname(median(bench$time) / 1e6),
     mean_ms = unname(mean(bench$time) / 1e6),
@@ -92,6 +127,7 @@ to_row <- function(name, bench, n_obs, n_items) {
 res <- rbind(
   to_row("prepare_large", bench_prepare, N_prepare, J),
   to_row("fit_large", bench_fit, N_fit, J),
+  to_row("itemtrace_large", bench_itemtrace, theta_n, J),
   to_row("eapsum_large", bench_eapsum, N_fit, J)
 )
 

--- a/man/mirtCluster.Rd
+++ b/man/mirtCluster.Rd
@@ -11,7 +11,7 @@ mirtCluster(spec, omp_threads, remove = FALSE, use_mirai = TRUE, ...)
 maximum number of available local cores minus 1 will be used.
 Setting this to NULL will skip a new definition (allows \code{omp_threads} to be used independently)}
 
-\item{omp_threads}{number of OpenMP threads to use (currently applies to E-step computations only).
+\item{omp_threads}{number of OpenMP threads to use for OpenMP-backed E-step and item trace computations.
 Not used when argument input is missing}
 
 \item{remove}{logical; remove previously defined \code{mirtCluster()}?}

--- a/src/Estep.cpp
+++ b/src/Estep.cpp
@@ -12,12 +12,6 @@
 
 const double ABSMIN = std::numeric_limits<double>::min();
 
-void if_omp_set_num_threads(const int &omp_threads){
-    #ifdef _OPENMP
-        omp_set_num_threads(omp_threads);
-    #endif
-}
-
 void _Estep(vector<double> &expected, vector<double> &r1vec, vector<double> &r1g,
     const vector<double> &prior, const vector<double> &r, 
     const IntegerMatrix &data, const NumericMatrix &itemtrace,

--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -1,9 +1,19 @@
 #include "Misc.h"
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 // hack fix
 void R_init_mirt(DllInfo* info) {
     R_registerRoutines(info, NULL, NULL, NULL, NULL);
     R_useDynamicSymbols(info, TRUE);
+}
+
+void if_omp_set_num_threads(const int &omp_threads){
+    #ifdef _OPENMP
+        omp_set_num_threads(omp_threads);
+    #endif
 }
 
 NumericMatrix polyOuter(const NumericMatrix &Thetas, const vector<double> &Pk,

--- a/src/Misc.h
+++ b/src/Misc.h
@@ -17,6 +17,8 @@ double vecsum(const vector<double> &);
 
 SEXP vec2mat(vector<double> &, const int &, const int &);
 
+void if_omp_set_num_threads(const int &);
+
 const double ABS_MAX_Z = 35;
 
 #endif

--- a/src/traceLinePts.cpp
+++ b/src/traceLinePts.cpp
@@ -790,6 +790,101 @@ void P_switch(vector<double> &P, const vector<double> &par,
     }
 }
 
+void _computeItemTrace_serial(vector<double> &itemtrace, const NumericMatrix &Theta,
+    const List &pars, const NumericVector &ot, const vector<int> &itemloc, const int &which,
+    const int &nfact, const int &N, const int &usefixed)
+{
+    const NumericMatrix* theta_ptr = &Theta;
+    NumericMatrix theta_fixed;
+    int nfact2 = nfact;
+    S4 item = pars[which];
+    int ncat = as<int>(item.slot("ncat"));
+    vector<double> par = as< vector<double> >(item.slot("par"));
+    vector<double> P(N*ncat);
+    int itemclass = as<int>(item.slot("itemclass"));
+    int correct = 0;
+    int has_mat = 0;
+    int k = 1;
+    IntegerVector cpow;
+    IntegerVector factor_ind;
+    IntegerVector fixed_ind;
+    if(itemclass == 7){
+        cpow = as<IntegerVector>(item.slot("cpow"));
+        factor_ind = as<IntegerVector>(item.slot("factor.ind"));
+        fixed_ind = as<IntegerVector>(item.slot("fixed.ind"));
+    }
+    if(itemclass == 8)
+        correct = as<int>(item.slot("correctcat"));
+    if(itemclass == 12)
+        k = as<int>(item.slot("k"));
+    NumericMatrix item_Q;
+    if(itemclass == 10)
+        item_Q = as<NumericMatrix>(item.slot("item.Q"));
+
+    if(usefixed){
+        NumericMatrix itemFD = item.slot("fixed.design");
+        nfact2 = nfact + itemFD.ncol();
+        theta_fixed = NumericMatrix(Theta.nrow(), nfact2);
+        if(itemFD.nrow() == 1){
+            for(int j = 0; j < Theta.nrow(); ++j)
+                for(int i = 0; i < itemFD.ncol(); ++i)
+                    theta_fixed(j,i) = itemFD(0,i);
+        } else {
+            for(int i = 0; i < itemFD.ncol(); ++i)
+                theta_fixed(_,i) = itemFD(_,i);
+        }
+        for(int i = 0; i < nfact; ++i)
+            theta_fixed(_,i+itemFD.ncol()) = Theta(_,i);
+        theta_ptr = &theta_fixed;
+    }
+    const NumericMatrix &theta = *theta_ptr;
+    switch(itemclass){
+        case 1 :
+            P_dich(P, par, theta, ot, N, nfact2);
+            break;
+        case 2 :
+            P_graded(P, par, theta, ot, N, nfact2, ncat-1, 1, 0);
+            break;
+        case 3 :
+            has_mat = as<int>(item.slot("mat"));
+            if(has_mat) P_nominal2(P, par, theta, ot, N, nfact2, ncat, 0, 0);
+                else P_nominal(P, par, theta, ot, N, nfact2, ncat, 0, 0);
+            break;
+        case 4 :
+            P_nominal(P, par, theta, ot, N, nfact2, ncat, 0, 0);
+            break;
+        case 5 :
+            P_graded(P, par, theta, ot, N, nfact2, ncat-1, 1, 1);
+            break;
+        case 6 :
+            P_gpcmIRT(P, par, theta, ot, N, nfact2, ncat);
+            break;
+        case 7 :
+            P_comp(P, par, theta, N, nfact2, cpow, factor_ind, fixed_ind);
+            break;
+        case 8 :
+            P_nested(P, par, theta, N, nfact2, ncat, correct);
+            break;
+        case 9 :
+            P_ideal(P, par, theta, ot, N, nfact2);
+            break;
+        case 10 :
+            P_lca(P, par, theta, item_Q, N, ncat, nfact2, 0);
+            break;
+        case 11 :
+            P_ggum(P, par, theta, N, nfact2, ncat);
+            break;
+        case 12 :
+            P_monopoly(P, par, Theta, N, nfact2, ncat, k);
+            break;
+        default :
+            P_switch(P, par, theta, ot, N, ncat, nfact, k, itemclass);
+    }
+    int where = (itemloc[which]-1) * N;
+    for(int i = 0; i < N*ncat; ++i)
+        itemtrace[where + i] = P[i];
+}
+
 void _computeItemTrace(vector<double> &itemtrace, const NumericMatrix &Theta,
     const ItemTraceData &item, const vector<int> &itemloc, const int &which,
     const int &nfact, const int &N)
@@ -881,51 +976,62 @@ RcppExport SEXP computeItemTrace(SEXP Rpars, SEXP RTheta, SEXP Ritemloc, SEXP Ro
     const int nfact = Theta.ncol();
     const int N = Theta.nrow();
     vector<double> itemtrace(N * (itemloc[J]-1));
-    vector<ItemTraceData> items(J);
     if_omp_set_num_threads(omp_threads);
-    for(int which = 0; which < J; ++which){
-        S4 item = pars[which];
-        ItemTraceData &itemdat = items[which];
-        itemdat.ncat = as<int>(item.slot("ncat"));
-        itemdat.par = as< vector<double> >(item.slot("par"));
-        itemdat.itemclass = as<int>(item.slot("itemclass"));
-        itemdat.correct = itemdat.itemclass == 8 ? as<int>(item.slot("correctcat")) : 0;
-        itemdat.has_mat = itemdat.itemclass == 3 ? as<int>(item.slot("mat")) : 0;
-        itemdat.k = itemdat.itemclass == 12 ? as<int>(item.slot("k")) : 1;
-        itemdat.usefixed = as<int>(item.slot("nfixedeffects")) > 0;
-        itemdat.ot = NumericVector(offterm.nrow());
-        for(int i = 0; i < offterm.nrow(); ++i)
-            itemdat.ot[i] = offterm(i, which);
-        if(itemdat.itemclass == 7){
-            itemdat.cpow = clone(as<IntegerVector>(item.slot("cpow")));
-            itemdat.factor_ind = clone(as<IntegerVector>(item.slot("factor.ind")));
-            itemdat.fixed_ind = clone(as<IntegerVector>(item.slot("fixed.ind")));
-        }
-        if(itemdat.itemclass == 10)
-            itemdat.item_Q = clone(as<NumericMatrix>(item.slot("item.Q")));
-        if(itemdat.usefixed){
-            const NumericMatrix itemFD = as<NumericMatrix>(item.slot("fixed.design"));
-            itemdat.theta_fixed = NumericMatrix(N, nfact + itemFD.ncol());
-            if(itemFD.nrow() == 1){
-                for(int j = 0; j < N; ++j)
-                    for(int i = 0; i < itemFD.ncol(); ++i)
-                        itemdat.theta_fixed(j,i) = itemFD(0,i);
-            } else {
-                for(int j = 0; j < N; ++j)
-                    for(int i = 0; i < itemFD.ncol(); ++i)
-                        itemdat.theta_fixed(j,i) = itemFD(j,i);
-            }
-            for(int j = 0; j < N; ++j)
-                for(int i = 0; i < nfact; ++i)
-                    itemdat.theta_fixed(j, i + itemFD.ncol()) = Theta(j,i);
-        }
-    }
+    vector<int> usefixed(J);
+    for(int which = 0; which < J; ++which)
+        usefixed[which] = as<int>(as<S4>(pars[which]).slot("nfixedeffects")) > 0;
     #ifdef _OPENMP
     const int parallel = omp_threads > 1 && J > 1 && (J * N) >= ITEMTRACE_OMP_MIN_WORK;
-    #pragma omp parallel for if(parallel) schedule(static)
+    if(parallel){
+        vector<ItemTraceData> items(J);
+        for(int which = 0; which < J; ++which){
+            S4 item = pars[which];
+            ItemTraceData &itemdat = items[which];
+            itemdat.ncat = as<int>(item.slot("ncat"));
+            itemdat.par = as< vector<double> >(item.slot("par"));
+            itemdat.itemclass = as<int>(item.slot("itemclass"));
+            itemdat.correct = itemdat.itemclass == 8 ? as<int>(item.slot("correctcat")) : 0;
+            itemdat.has_mat = itemdat.itemclass == 3 ? as<int>(item.slot("mat")) : 0;
+            itemdat.k = itemdat.itemclass == 12 ? as<int>(item.slot("k")) : 1;
+            itemdat.usefixed = usefixed[which];
+            itemdat.ot = NumericVector(offterm.nrow());
+            for(int i = 0; i < offterm.nrow(); ++i)
+                itemdat.ot[i] = offterm(i, which);
+            if(itemdat.itemclass == 7){
+                itemdat.cpow = clone(as<IntegerVector>(item.slot("cpow")));
+                itemdat.factor_ind = clone(as<IntegerVector>(item.slot("factor.ind")));
+                itemdat.fixed_ind = clone(as<IntegerVector>(item.slot("fixed.ind")));
+            }
+            if(itemdat.itemclass == 10)
+                itemdat.item_Q = clone(as<NumericMatrix>(item.slot("item.Q")));
+            if(itemdat.usefixed){
+                const NumericMatrix itemFD = as<NumericMatrix>(item.slot("fixed.design"));
+                itemdat.theta_fixed = NumericMatrix(N, nfact + itemFD.ncol());
+                if(itemFD.nrow() == 1){
+                    for(int j = 0; j < N; ++j)
+                        for(int i = 0; i < itemFD.ncol(); ++i)
+                            itemdat.theta_fixed(j,i) = itemFD(0,i);
+                } else {
+                    for(int j = 0; j < N; ++j)
+                        for(int i = 0; i < itemFD.ncol(); ++i)
+                            itemdat.theta_fixed(j,i) = itemFD(j,i);
+                }
+                for(int j = 0; j < N; ++j)
+                    for(int i = 0; i < nfact; ++i)
+                        itemdat.theta_fixed(j, i + itemFD.ncol()) = Theta(j,i);
+            }
+        }
+        #pragma omp parallel for schedule(static)
+        for(int which = 0; which < J; ++which)
+            _computeItemTrace(itemtrace, Theta, items[which], itemloc, which, nfact, N);
+    } else {
     #endif
-    for(int which = 0; which < J; ++which)
-        _computeItemTrace(itemtrace, Theta, items[which], itemloc, which, nfact, N);
+        for(int which = 0; which < J; ++which)
+            _computeItemTrace_serial(itemtrace, Theta, pars, offterm(_, which), itemloc,
+                which, nfact, N, usefixed[which]);
+    #ifdef _OPENMP
+    }
+    #endif
 
     NumericMatrix ret = vec2mat(itemtrace, N, itemloc[J]-1);
     return(ret);

--- a/src/traceLinePts.cpp
+++ b/src/traceLinePts.cpp
@@ -1,6 +1,11 @@
 #include "Misc.h"
 #include "traceLinePts.h"
 
+#ifdef _OPENMP
+#include <omp.h>
+const int ITEMTRACE_OMP_MIN_WORK = 10000;
+#endif
+
 void itemTrace(vector<double> &P, vector<double> &Pstar, const vector<double> &a, const double *d,
         const NumericMatrix &Theta, const double *g, const double *u, const NumericVector &ot)
 {
@@ -786,35 +791,15 @@ void P_switch(vector<double> &P, const vector<double> &par,
 }
 
 void _computeItemTrace(vector<double> &itemtrace, const NumericMatrix &Theta,
-    const List &pars, const NumericVector &ot, const vector<int> &itemloc, const int &which,
-    const int &nfact, const int &N, const int &usefixed)
+    const ItemTraceData &item, const vector<int> &itemloc, const int &which,
+    const int &nfact, const int &N)
 {
     const NumericMatrix* theta_ptr = &Theta;
-    NumericMatrix theta_fixed;
     int nfact2 = nfact;
-    S4 item = pars[which];
-    int ncat = as<int>(item.slot("ncat"));
-    vector<double> par = as< vector<double> >(item.slot("par"));
+    const int ncat = item.ncat;
+    const vector<double> &par = item.par;
     vector<double> P(N*ncat);
-    int itemclass = as<int>(item.slot("itemclass"));
-    int correct = 0;
-    int has_mat = 0;
-    int k = 1;
-    IntegerVector cpow;
-    IntegerVector factor_ind;
-    IntegerVector fixed_ind;
-    if(itemclass == 7){
-        cpow = as<IntegerVector>(item.slot("cpow"));
-        factor_ind = as<IntegerVector>(item.slot("factor.ind"));
-        fixed_ind = as<IntegerVector>(item.slot("fixed.ind"));
-    }
-    if(itemclass == 8)
-        correct = as<int>(item.slot("correctcat"));
-    if(itemclass == 12)
-        k = as<int>(item.slot("k"));
-    NumericMatrix item_Q;
-    if(itemclass == 10)
-        item_Q = as<NumericMatrix>(item.slot("item.Q"));
+    const int itemclass = item.itemclass;
 
     /*
         1 = dich
@@ -831,71 +816,59 @@ void _computeItemTrace(vector<double> &itemtrace, const NumericMatrix &Theta,
         12 = monopoly
     */
 
-    if(usefixed){
-        NumericMatrix itemFD = item.slot("fixed.design");
-        nfact2 = nfact + itemFD.ncol();
-        theta_fixed = NumericMatrix(Theta.nrow(), nfact2);
-        if(itemFD.nrow() == 1){
-            for(int j = 0; j < Theta.nrow(); ++j)
-                for(int i = 0; i < itemFD.ncol(); ++i)
-                    theta_fixed(j,i) = itemFD(0,i);
-        } else {
-            for(int i = 0; i < itemFD.ncol(); ++i)
-                theta_fixed(_,i) = itemFD(_,i);
-        }
-        for(int i = 0; i < nfact; ++i)
-            theta_fixed(_,i+itemFD.ncol()) = Theta(_,i);
-        theta_ptr = &theta_fixed;
+    if(item.usefixed){
+        nfact2 = item.theta_fixed.ncol();
+        theta_ptr = &item.theta_fixed;
     }
     const NumericMatrix &theta = *theta_ptr;
     switch(itemclass){
         case 1 :
-            P_dich(P, par, theta, ot, N, nfact2);
+            P_dich(P, par, theta, item.ot, N, nfact2);
             break;
         case 2 :
-            P_graded(P, par, theta, ot, N, nfact2, ncat-1, 1, 0);
+            P_graded(P, par, theta, item.ot, N, nfact2, ncat-1, 1, 0);
             break;
         case 3 :
-        	has_mat = as<int>(item.slot("mat"));
-        	if(has_mat) P_nominal2(P, par, theta, ot, N, nfact2, ncat, 0, 0);
-            	else P_nominal(P, par, theta, ot, N, nfact2, ncat, 0, 0);
+            if(item.has_mat) P_nominal2(P, par, theta, item.ot, N, nfact2, ncat, 0, 0);
+                else P_nominal(P, par, theta, item.ot, N, nfact2, ncat, 0, 0);
             break;
         case 4 :
-            P_nominal(P, par, theta, ot, N, nfact2, ncat, 0, 0);
+            P_nominal(P, par, theta, item.ot, N, nfact2, ncat, 0, 0);
             break;
         case 5 :
-            P_graded(P, par, theta, ot, N, nfact2, ncat-1, 1, 1);
+            P_graded(P, par, theta, item.ot, N, nfact2, ncat-1, 1, 1);
             break;
         case 6 :
-            P_gpcmIRT(P, par, theta, ot, N, nfact2, ncat);
+            P_gpcmIRT(P, par, theta, item.ot, N, nfact2, ncat);
             break;
         case 7 :
-            P_comp(P, par, theta, N, nfact2, cpow, factor_ind, fixed_ind);
+            P_comp(P, par, theta, N, nfact2, item.cpow, item.factor_ind, item.fixed_ind);
             break;
         case 8 :
-            P_nested(P, par, theta, N, nfact2, ncat, correct);
+            P_nested(P, par, theta, N, nfact2, ncat, item.correct);
             break;
         case 9 :
-            P_ideal(P, par, theta, ot, N, nfact2);
+            P_ideal(P, par, theta, item.ot, N, nfact2);
             break;
         case 10 :
-            P_lca(P, par, theta, item_Q, N, ncat, nfact2, 0);
+            P_lca(P, par, theta, item.item_Q, N, ncat, nfact2, 0);
             break;
         case 11 :
             P_ggum(P, par, theta, N, nfact2, ncat);
             break;
         case 12 :
-            P_monopoly(P, par, Theta, N, nfact2, ncat, k);
+            P_monopoly(P, par, Theta, N, nfact2, ncat, item.k);
             break;
         default :
-            P_switch(P, par, theta, ot, N, ncat, nfact, k, itemclass);
+            P_switch(P, par, theta, item.ot, N, ncat, nfact, item.k, itemclass);
     }
     int where = (itemloc[which]-1) * N;
     for(int i = 0; i < N*ncat; ++i)
         itemtrace[where + i] = P[i];
 }
 
-RcppExport SEXP computeItemTrace(SEXP Rpars, SEXP RTheta, SEXP Ritemloc, SEXP Roffterm)
+RcppExport SEXP computeItemTrace(SEXP Rpars, SEXP RTheta, SEXP Ritemloc, SEXP Roffterm,
+    SEXP Romp_threads)
 {
     BEGIN_RCPP
 
@@ -903,18 +876,56 @@ RcppExport SEXP computeItemTrace(SEXP Rpars, SEXP RTheta, SEXP Ritemloc, SEXP Ro
     const NumericMatrix Theta(RTheta);
     const NumericMatrix offterm(Roffterm);
     const vector<int> itemloc = as< vector<int> >(Ritemloc);
+    const int omp_threads = as<int>(Romp_threads);
     const int J = itemloc.size() - 1;
     const int nfact = Theta.ncol();
     const int N = Theta.nrow();
     vector<double> itemtrace(N * (itemloc[J]-1));
-    vector<int> usefixed(J);
+    vector<ItemTraceData> items(J);
+    if_omp_set_num_threads(omp_threads);
     for(int which = 0; which < J; ++which){
         S4 item = pars[which];
-        usefixed[which] = as<int>(item.slot("nfixedeffects")) > 0;
+        ItemTraceData &itemdat = items[which];
+        itemdat.ncat = as<int>(item.slot("ncat"));
+        itemdat.par = as< vector<double> >(item.slot("par"));
+        itemdat.itemclass = as<int>(item.slot("itemclass"));
+        itemdat.correct = itemdat.itemclass == 8 ? as<int>(item.slot("correctcat")) : 0;
+        itemdat.has_mat = itemdat.itemclass == 3 ? as<int>(item.slot("mat")) : 0;
+        itemdat.k = itemdat.itemclass == 12 ? as<int>(item.slot("k")) : 1;
+        itemdat.usefixed = as<int>(item.slot("nfixedeffects")) > 0;
+        itemdat.ot = NumericVector(offterm.nrow());
+        for(int i = 0; i < offterm.nrow(); ++i)
+            itemdat.ot[i] = offterm(i, which);
+        if(itemdat.itemclass == 7){
+            itemdat.cpow = clone(as<IntegerVector>(item.slot("cpow")));
+            itemdat.factor_ind = clone(as<IntegerVector>(item.slot("factor.ind")));
+            itemdat.fixed_ind = clone(as<IntegerVector>(item.slot("fixed.ind")));
+        }
+        if(itemdat.itemclass == 10)
+            itemdat.item_Q = clone(as<NumericMatrix>(item.slot("item.Q")));
+        if(itemdat.usefixed){
+            const NumericMatrix itemFD = as<NumericMatrix>(item.slot("fixed.design"));
+            itemdat.theta_fixed = NumericMatrix(N, nfact + itemFD.ncol());
+            if(itemFD.nrow() == 1){
+                for(int j = 0; j < N; ++j)
+                    for(int i = 0; i < itemFD.ncol(); ++i)
+                        itemdat.theta_fixed(j,i) = itemFD(0,i);
+            } else {
+                for(int j = 0; j < N; ++j)
+                    for(int i = 0; i < itemFD.ncol(); ++i)
+                        itemdat.theta_fixed(j,i) = itemFD(j,i);
+            }
+            for(int j = 0; j < N; ++j)
+                for(int i = 0; i < nfact; ++i)
+                    itemdat.theta_fixed(j, i + itemFD.ncol()) = Theta(j,i);
+        }
     }
+    #ifdef _OPENMP
+    const int parallel = omp_threads > 1 && J > 1 && (J * N) >= ITEMTRACE_OMP_MIN_WORK;
+    #pragma omp parallel for if(parallel) schedule(static)
+    #endif
     for(int which = 0; which < J; ++which)
-        _computeItemTrace(itemtrace, Theta, pars, offterm(_, which), itemloc,
-            which, nfact, N, usefixed[which]);
+        _computeItemTrace(itemtrace, Theta, items[which], itemloc, which, nfact, N);
 
     NumericMatrix ret = vec2mat(itemtrace, N, itemloc[J]-1);
     return(ret);

--- a/src/traceLinePts.h
+++ b/src/traceLinePts.h
@@ -42,8 +42,23 @@ void P_monopoly(vector<double> &, const vector<double> &,
     const NumericMatrix &, const int &,
     const int &, const int &, const int &);
 
+struct ItemTraceData {
+    vector<double> par;
+    NumericVector ot;
+    IntegerVector cpow;
+    IntegerVector factor_ind;
+    IntegerVector fixed_ind;
+    NumericMatrix item_Q;
+    NumericMatrix theta_fixed;
+    int ncat;
+    int itemclass;
+    int correct;
+    int has_mat;
+    int k;
+    int usefixed;
+};
+
 void _computeItemTrace(vector<double> &, const NumericMatrix &,
-    const List &, const NumericVector &, const vector<int> &, const int &,
-    const int &, const int &, const int &);
+    const ItemTraceData &, const vector<int> &, const int &, const int &, const int &);
 
 #endif

--- a/src/traceLinePts.h
+++ b/src/traceLinePts.h
@@ -58,6 +58,10 @@ struct ItemTraceData {
     int usefixed;
 };
 
+void _computeItemTrace_serial(vector<double> &, const NumericMatrix &,
+    const List &, const NumericVector &, const vector<int> &, const int &,
+    const int &, const int &, const int &);
+
 void _computeItemTrace(vector<double> &, const NumericMatrix &,
     const ItemTraceData &, const vector<int> &, const int &, const int &, const int &);
 

--- a/tests/testthat/test-10-extras.R
+++ b/tests/testthat/test-10-extras.R
@@ -81,6 +81,12 @@ test_that('extras', {
     expect_equal(pb[1:3, 1], c(0.9965890, 0.9963601, 0.9961159), tolerance = 1e-5)
     ti <- testinfo(mod1, Theta=Theta)
     expect_equal(ti[1:3], c(0.06607895, 0.06918330, 0.07242870), tolerance = 1e-5)
+    Theta_big <- matrix(seq(-6, 6, length.out=3000))
+    trace_serial <- mirt:::computeItemtrace(mod1@ParObjects$pars, Theta_big, mod1@Model$itemloc,
+                                            CUSTOM.IND=mod1@Internals$CUSTOM.IND, omp_threads=1L)
+    trace_parallel <- mirt:::computeItemtrace(mod1@ParObjects$pars, Theta_big, mod1@Model$itemloc,
+                                              CUSTOM.IND=mod1@Internals$CUSTOM.IND, omp_threads=2L)
+    expect_equal(trace_serial, trace_parallel)
     set.seed(1234)
     fs <- fscores(mod1, MI=20, verbose=FALSE, full.scores=FALSE)
     expect_class(fs, 'matrix')
@@ -104,4 +110,3 @@ test_that('extras', {
     expect_equal(abs(cfs), abs(c(0.7835446,2.088519,4.489773,0.6727285,0.2357904,0.3148114,1.736133,0.3861383,0.07062774,6.563708,1.01623,0.05366885,0.2764068,-5.030398,-0.1089204,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,0,0,0,0,3,3,3,3,0,0,0,0,0,0,0,0,0,0,0,0,2.737057,9.954572,8.696347,2.051471,1.746521,1.493303,4.871186,2.184036,5.174404,13.00528,12.46809,2.830379,4.335373,6.261805,7.718796,3.259992,3.88189,5.255669,9.140148,1.683119,4.413986,6.18042,8.669859,3.579751,NA,NA,NA,NA,4,4,4,4,NA,NA,NA,NA,5,5,5,5,NA,NA,NA,NA,0,0,0,0,NA,NA,NA,NA,0,0,0,0,NA,NA,NA,NA,4.178023,5.776866,7.750279,3.300487,NA,NA,NA,NA,3.043197,4.313529,5.190609,1.550788)), tolerance=1e-4)
 
 })
-


### PR DESCRIPTION
Use OpenMP for larger computeItemTrace workloads and thread the omp_threads setting through item-trace callers so fscores and related workflows can benefit without changing results.

closes #277 